### PR TITLE
Implement integration BFF endpoints and web wiring

### DIFF
--- a/analytics-stack/apps/Next-js-Boilerplate/src/app/[locale]/(auth)/analytics/page.tsx
+++ b/analytics-stack/apps/Next-js-Boilerplate/src/app/[locale]/(auth)/analytics/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { AnalyticsOverview } from "@shared-types/index";
+import { bffFetch } from "@/lib/bff";
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat().format(Math.round(value));
+}
+
+function formatPercent(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatDuration(seconds: number) {
+  const rounded = Math.round(seconds);
+  const minutes = Math.floor(rounded / 60);
+  const remaining = rounded % 60;
+  return `${minutes}m ${remaining}s`;
+}
+
+export default function AnalyticsPage() {
+  const [overview, setOverview] = useState<AnalyticsOverview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const to = new Date();
+    const from = new Date(to);
+    from.setDate(from.getDate() - 7);
+
+    bffFetch<AnalyticsOverview>(
+      `/api/analytics/overview?from=${from.toISOString()}&to=${to.toISOString()}`,
+    )
+      .then((data) => {
+        setOverview(data);
+      })
+      .catch((error) => {
+        setError(error instanceof Error ? error.message : "Unknown error");
+      });
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <h1 className="text-2xl font-semibold">Analytics overview</h1>
+        <p className="text-sm text-muted-foreground">
+          Last 7 days of Umami website performance aggregated via the integration BFF.
+        </p>
+      </section>
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+      {overview ? (
+        <dl className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <MetricCard title="Pageviews" value={formatNumber(overview.pageviews.current)} delta={overview.pageviews.delta} />
+          <MetricCard title="Visitors" value={formatNumber(overview.visitors.current)} delta={overview.visitors.delta} />
+          <MetricCard title="Visits" value={formatNumber(overview.visits.current)} delta={overview.visits.delta} />
+          <MetricCard
+            title="Bounce rate"
+            value={formatPercent(overview.bounceRate.current)}
+            delta={overview.bounceRate.delta}
+            isPercentage
+          />
+          <MetricCard
+            title="Avg. visit duration"
+            value={formatDuration(overview.avgVisitDuration.current)}
+            delta={overview.avgVisitDuration.delta}
+          />
+        </dl>
+      ) : (
+        <p className="text-sm text-muted-foreground">Loading latest analytics…</p>
+      )}
+    </div>
+  );
+}
+
+interface MetricCardProps {
+  title: string;
+  value: string;
+  delta: number;
+  isPercentage?: boolean;
+}
+
+function MetricCard({ title, value, delta, isPercentage }: MetricCardProps) {
+  const sign = delta === 0 ? "" : delta > 0 ? "+" : "";
+  const formattedDelta = isPercentage ? formatPercent(delta) : formatNumber(delta);
+
+  return (
+    <div className="space-y-2 rounded-lg border p-4">
+      <dt className="text-sm text-muted-foreground">{title}</dt>
+      <dd className="text-2xl font-semibold">{value}</dd>
+      <p className="text-xs text-muted-foreground">{`${sign}${formattedDelta}`} vs previous period</p>
+    </div>
+  );
+}

--- a/analytics-stack/apps/Next-js-Boilerplate/src/app/[locale]/(auth)/links/page.tsx
+++ b/analytics-stack/apps/Next-js-Boilerplate/src/app/[locale]/(auth)/links/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import type { Link } from "@shared-types/index";
+import { bffFetch } from "@/lib/bff";
+
+interface FormState {
+  url: string;
+  domain: string;
+  key: string;
+}
+
+const initialForm: FormState = {
+  url: "",
+  domain: "",
+  key: "",
+};
+
+export default function LinksPage() {
+  const [form, setForm] = useState<FormState>(initialForm);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [link, setLink] = useState<Link | null>(null);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPending(true);
+    setError(null);
+
+    try {
+      const result = await bffFetch<Link>("/api/links", {
+        method: "POST",
+        body: JSON.stringify({
+          url: form.url,
+          domain: form.domain || undefined,
+          key: form.key || undefined,
+        }),
+      });
+
+      setLink(result);
+      setForm(initialForm);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "Unknown error");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <h1 className="text-2xl font-semibold">Create a short link</h1>
+        <p className="text-sm text-muted-foreground">
+          Submit a destination URL and optional domain/slug to provision a new Dub link via the integration BFF.
+        </p>
+      </section>
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border p-6 shadow-sm">
+        <div className="space-y-2">
+          <label htmlFor="url" className="block text-sm font-medium">
+            Destination URL
+          </label>
+          <input
+            id="url"
+            name="url"
+            type="url"
+            required
+            value={form.url}
+            onChange={(event) => setForm((state) => ({ ...state, url: event.target.value }))}
+            placeholder="https://example.com"
+            className="w-full rounded-md border px-3 py-2"
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label htmlFor="domain" className="block text-sm font-medium">
+              Domain (optional)
+            </label>
+            <input
+              id="domain"
+              name="domain"
+              value={form.domain}
+              onChange={(event) => setForm((state) => ({ ...state, domain: event.target.value }))}
+              placeholder="dub.sh"
+              className="w-full rounded-md border px-3 py-2"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="key" className="block text-sm font-medium">
+              Slug (optional)
+            </label>
+            <input
+              id="key"
+              name="key"
+              value={form.key}
+              onChange={(event) => setForm((state) => ({ ...state, key: event.target.value }))}
+              placeholder="launch"
+              className="w-full rounded-md border px-3 py-2"
+            />
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md bg-black px-4 py-2 text-white disabled:opacity-60"
+        >
+          {pending ? "Creating…" : "Create link"}
+        </button>
+      </form>
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+      {link ? (
+        <div className="space-y-2 rounded-lg border p-4">
+          <h2 className="font-medium">Latest link</h2>
+          <dl className="grid gap-1 text-sm">
+            <div className="flex gap-2">
+              <dt className="w-32 text-muted-foreground">Short link</dt>
+              <dd>{link.shortLink}</dd>
+            </div>
+            <div className="flex gap-2">
+              <dt className="w-32 text-muted-foreground">Destination</dt>
+              <dd>{link.url}</dd>
+            </div>
+            <div className="flex gap-2">
+              <dt className="w-32 text-muted-foreground">Created</dt>
+              <dd>{new Date(link.createdAt).toLocaleString()}</dd>
+            </div>
+          </dl>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/analytics-stack/apps/Next-js-Boilerplate/src/app/api/analytics/overview/route.ts
+++ b/analytics-stack/apps/Next-js-Boilerplate/src/app/api/analytics/overview/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { AnalyticsOverviewSchema, AnalyticsQuerySchema } from "@shared-types/index";
+import { getOverview, UmamiSdkError } from "@sdk-umami/index";
+import { requireAuth, UnauthorizedError } from "@/server/require-auth";
+
+export async function GET(request: Request) {
+  try {
+    await requireAuth();
+
+    const url = new URL(request.url);
+    const params = Object.fromEntries(url.searchParams.entries());
+    const parsed = AnalyticsQuerySchema.parse(params);
+
+    const overview = await getOverview(parsed);
+
+    return NextResponse.json(AnalyticsOverviewSchema.parse(overview));
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: error.message }, { status: error.status });
+    }
+
+    if (error instanceof UmamiSdkError) {
+      return NextResponse.json({ message: error.message }, { status: error.status ?? 502 });
+    }
+
+    if (error instanceof Error) {
+      return NextResponse.json({ message: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ message: "Unknown error" }, { status: 500 });
+  }
+}

--- a/analytics-stack/apps/Next-js-Boilerplate/src/app/api/health/route.ts
+++ b/analytics-stack/apps/Next-js-Boilerplate/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ ok: true, service: "integration-bff" });
+}

--- a/analytics-stack/apps/Next-js-Boilerplate/src/app/api/links/route.ts
+++ b/analytics-stack/apps/Next-js-Boilerplate/src/app/api/links/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { LinkCreateInputSchema, LinkSchema } from "@shared-types/index";
+import { createLink, DubSdkError } from "@sdk-dub/index";
+import { requireAuth, UnauthorizedError } from "@/server/require-auth";
+
+export async function POST(request: Request) {
+  try {
+    await requireAuth();
+
+    const json = await request.json();
+    const payload = LinkCreateInputSchema.parse(json);
+
+    const link = await createLink(payload);
+
+    return NextResponse.json(LinkSchema.parse(link));
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: error.message }, { status: error.status });
+    }
+
+    if (error instanceof DubSdkError) {
+      return NextResponse.json({ message: error.message }, { status: error.status ?? 502 });
+    }
+
+    if (error instanceof Error) {
+      return NextResponse.json({ message: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ message: "Unknown error" }, { status: 500 });
+  }
+}

--- a/analytics-stack/apps/Next-js-Boilerplate/src/lib/bff.ts
+++ b/analytics-stack/apps/Next-js-Boilerplate/src/lib/bff.ts
@@ -1,0 +1,27 @@
+const baseUrl = process.env.NEXT_PUBLIC_BFF_URL?.replace(/\/$/, "");
+
+export async function bffFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = baseUrl ? `${baseUrl}${path}` : path;
+  const headers = new Headers(init?.headers);
+
+  if (init?.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(url, {
+    ...init,
+    headers,
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `BFF request failed with status ${response.status}`);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}

--- a/analytics-stack/apps/Next-js-Boilerplate/src/server/require-auth.ts
+++ b/analytics-stack/apps/Next-js-Boilerplate/src/server/require-auth.ts
@@ -1,0 +1,35 @@
+import { auth, currentUser } from "@clerk/nextjs/server";
+import { UserIdentitySchema, type UserIdentity } from "@shared-types/index";
+
+export class UnauthorizedError extends Error {
+  status = 401;
+
+  constructor(message = "Unauthorized") {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export async function requireAuth(): Promise<UserIdentity> {
+  const { userId, orgId } = auth();
+
+  if (!userId) {
+    throw new UnauthorizedError();
+  }
+
+  const user = await currentUser();
+
+  if (!user) {
+    throw new UnauthorizedError();
+  }
+
+  const primaryEmail = user.emailAddresses.find((entry) => entry.id === user.primaryEmailAddressId)?.emailAddress;
+  const fallbackEmail = user.emailAddresses.at(0)?.emailAddress;
+
+  return UserIdentitySchema.parse({
+    id: user.id,
+    email: primaryEmail ?? fallbackEmail ?? null,
+    name: user.fullName ?? null,
+    orgId: orgId ?? user.organizationMemberships.at(0)?.organization.id ?? null,
+  });
+}

--- a/analytics-stack/apps/Next-js-Boilerplate/tsconfig.json
+++ b/analytics-stack/apps/Next-js-Boilerplate/tsconfig.json
@@ -59,7 +59,10 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@/public/*": ["./public/*"]
+      "@/public/*": ["./public/*"],
+      "@shared-types/*": ["../packages/shared-types/src/*"],
+      "@sdk-dub/*": ["../packages/sdk-dub/src/*"],
+      "@sdk-umami/*": ["../packages/sdk-umami/src/*"]
     },
 
     // ======================================================================
@@ -74,5 +77,14 @@
 
   // Files to include/exclude from the project
   "exclude": ["node_modules", "**/*.spec.ts", "**/*.e2e.ts"],
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "**/*.mts"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "**/*.mts",
+    "../packages/shared-types/src/**/*.ts",
+    "../packages/sdk-dub/src/**/*.ts",
+    "../packages/sdk-umami/src/**/*.ts"
+  ]
 }

--- a/analytics-stack/packages/sdk-dub/src/index.ts
+++ b/analytics-stack/packages/sdk-dub/src/index.ts
@@ -1,0 +1,71 @@
+import { LinkSchema, type Link, type LinkCreateInput } from "@shared-types/index";
+
+const DUB_BASE_URL = process.env.DUB_BASE_URL;
+const DUB_API_TOKEN = process.env.DUB_API_TOKEN;
+const DEFAULT_WORKSPACE_ID = process.env.DUB_WORKSPACE_ID;
+
+export class DubSdkError extends Error {
+  status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "DubSdkError";
+    this.status = status;
+  }
+}
+
+function assertEnv(value: string | undefined, key: string) {
+  if (!value) {
+    throw new DubSdkError(`Missing ${key} environment variable`);
+  }
+  return value;
+}
+
+export async function createLink(input: LinkCreateInput): Promise<Link> {
+  const baseUrl = assertEnv(DUB_BASE_URL, "DUB_BASE_URL");
+  const apiToken = assertEnv(DUB_API_TOKEN, "DUB_API_TOKEN");
+  const workspaceId = input.workspaceId ?? DEFAULT_WORKSPACE_ID;
+
+  if (!workspaceId) {
+    throw new DubSdkError("A workspaceId must be provided either in the payload or DUB_WORKSPACE_ID env var.");
+  }
+
+  const url = new URL("/api/links", baseUrl);
+  url.searchParams.set("workspaceId", workspaceId);
+
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiToken}`,
+    },
+    body: JSON.stringify({
+      url: input.url,
+      domain: input.domain,
+      key: input.key,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new DubSdkError(text || "Failed to create link", response.status);
+  }
+
+  const data = await response.json();
+
+  // apps/dub/apps/web/app/api/links/route.ts handles POST /api/links requests. 【F:apps/dub/apps/web/app/api/links/route.ts†L86-L151】
+  const parsed = LinkSchema.safeParse({
+    id: data.id,
+    shortLink: data.shortLink ?? data.short_link,
+    url: data.url,
+    domain: data.domain,
+    key: data.key,
+    createdAt: data.createdAt ?? data.created_at ?? new Date().toISOString(),
+  });
+
+  if (!parsed.success) {
+    throw new DubSdkError(parsed.error.message);
+  }
+
+  return parsed.data;
+}

--- a/analytics-stack/packages/sdk-umami/src/index.ts
+++ b/analytics-stack/packages/sdk-umami/src/index.ts
@@ -1,0 +1,99 @@
+import {
+  AnalyticsOverviewSchema,
+  MetricDeltaSchema,
+  type AnalyticsOverview,
+  type AnalyticsQuery,
+} from "@shared-types/index";
+
+export class UmamiSdkError extends Error {
+  status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "UmamiSdkError";
+    this.status = status;
+  }
+}
+
+const UMAMI_BASE_URL = process.env.UMAMI_BASE_URL;
+const UMAMI_API_TOKEN = process.env.UMAMI_API_TOKEN;
+const UMAMI_WEBSITE_ID = process.env.UMAMI_WEBSITE_ID;
+
+function assertEnv(value: string | undefined, key: string) {
+  if (!value) {
+    throw new UmamiSdkError(`Missing ${key} environment variable`);
+  }
+  return value;
+}
+
+function buildMetric(current: number, previous: number) {
+  return MetricDeltaSchema.parse({
+    current,
+    previous,
+    delta: current - previous,
+  });
+}
+
+export async function getOverview(query: AnalyticsQuery): Promise<AnalyticsOverview> {
+  const baseUrl = assertEnv(UMAMI_BASE_URL, "UMAMI_BASE_URL");
+  const apiToken = assertEnv(UMAMI_API_TOKEN, "UMAMI_API_TOKEN");
+  const websiteId = assertEnv(UMAMI_WEBSITE_ID, "UMAMI_WEBSITE_ID");
+
+  const from = new Date(query.from);
+  const to = new Date(query.to);
+
+  if (Number.isNaN(from.valueOf()) || Number.isNaN(to.valueOf())) {
+    throw new UmamiSdkError("Invalid date range supplied to analytics overview");
+  }
+
+  const url = new URL(`/api/websites/${websiteId}/stats`, baseUrl);
+  url.searchParams.set("startAt", from.valueOf().toString());
+  url.searchParams.set("endAt", to.valueOf().toString());
+
+  if (query.pathname) {
+    url.searchParams.set("url", query.pathname);
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new UmamiSdkError(text || "Failed to load analytics overview", response.status);
+  }
+
+  const payload = await response.json();
+
+  // apps/umami/src/app/api/websites/[websiteId]/stats/route.ts exposes GET /api/websites/:id/stats. 【F:apps/umami/src/app/api/websites/[websiteId]/stats/route.ts†L9-L62】
+  const pageviews = payload.pageviews ?? {};
+  const visitors = payload.visitors ?? {};
+  const visits = payload.visits ?? {};
+  const bounces = payload.bounces ?? {};
+  const totaltime = payload.totaltime ?? {};
+
+  const visitsCurrent = Number(visits.value ?? 0);
+  const visitsPrevious = Number(visits.prev ?? 0);
+  const bouncesCurrent = Number(bounces.value ?? 0);
+  const bouncesPrevious = Number(bounces.prev ?? 0);
+  const totalTimeCurrent = Number(totaltime.value ?? 0);
+  const totalTimePrevious = Number(totaltime.prev ?? 0);
+
+  const overview = AnalyticsOverviewSchema.parse({
+    pageviews: buildMetric(Number(pageviews.value ?? 0), Number(pageviews.prev ?? 0)),
+    visitors: buildMetric(Number(visitors.value ?? 0), Number(visitors.prev ?? 0)),
+    visits: buildMetric(visitsCurrent, visitsPrevious),
+    bounceRate: buildMetric(
+      visitsCurrent ? bouncesCurrent / Math.max(visitsCurrent, 1) : 0,
+      visitsPrevious ? bouncesPrevious / Math.max(visitsPrevious, 1) : 0,
+    ),
+    avgVisitDuration: buildMetric(
+      visitsCurrent ? totalTimeCurrent / Math.max(visitsCurrent, 1) : 0,
+      visitsPrevious ? totalTimePrevious / Math.max(visitsPrevious, 1) : 0,
+    ),
+  });
+
+  return overview;
+}

--- a/analytics-stack/packages/shared-types/src/index.ts
+++ b/analytics-stack/packages/shared-types/src/index.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+export const UserIdentitySchema = z.object({
+  id: z.string(),
+  email: z.string().email().nullish(),
+  name: z.string().nullish(),
+  orgId: z.string().nullish(),
+});
+
+export type UserIdentity = z.infer<typeof UserIdentitySchema>;
+
+export const LinkCreateInputSchema = z
+  .object({
+    url: z.string().url(),
+    domain: z.string().min(1).optional(),
+    key: z.string().min(1).optional(),
+    workspaceId: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type LinkCreateInput = z.infer<typeof LinkCreateInputSchema>;
+
+export const LinkSchema = z
+  .object({
+    id: z.string(),
+    shortLink: z.string().url(),
+    url: z.string().url(),
+    domain: z.string(),
+    key: z.string(),
+    createdAt: z.string(),
+  })
+  .strict();
+
+export type Link = z.infer<typeof LinkSchema>;
+
+export const AnalyticsQuerySchema = z
+  .object({
+    from: z.string(),
+    to: z.string(),
+    pathname: z.string().optional(),
+    limit: z.coerce.number().int().positive().max(100).optional(),
+  })
+  .strict();
+
+export type AnalyticsQuery = z.infer<typeof AnalyticsQuerySchema>;
+
+export const MetricDeltaSchema = z
+  .object({
+    current: z.number(),
+    previous: z.number(),
+    delta: z.number(),
+  })
+  .strict();
+
+export type MetricDelta = z.infer<typeof MetricDeltaSchema>;
+
+export const AnalyticsOverviewSchema = z
+  .object({
+    pageviews: MetricDeltaSchema,
+    visitors: MetricDeltaSchema,
+    visits: MetricDeltaSchema,
+    bounceRate: MetricDeltaSchema,
+    avgVisitDuration: MetricDeltaSchema,
+  })
+  .strict();
+
+export type AnalyticsOverview = z.infer<typeof AnalyticsOverviewSchema>;


### PR DESCRIPTION
## Summary
- add shared Zod schemas and SDK helpers that normalize Dub link creation and Umami overview responses with vendor references
- expose Clerk-protected Next.js API routes for health, link creation, and analytics overview that use the shared helpers
- wire a reusable BFF fetch helper and minimal authenticated UI pages for link creation and analytics consumption

## Testing
- npm run lint --prefix apps/Next-js-Boilerplate *(fails: missing @antfu/eslint-config dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dee6ce44088326b78b65623c193913